### PR TITLE
Add metric data to eventlog-summary

### DIFF
--- a/opentelemetry-extra/exe/eventlog-summary/Main.hs
+++ b/opentelemetry-extra/exe/eventlog-summary/Main.hs
@@ -10,10 +10,11 @@ import qualified Data.HashTable.IO as H
 import Text.Printf
 import Data.List (sortOn)
 import Data.Word
+import Data.IORef
 
 type HashTable k v = H.BasicHashTable k v
 
-data PerOperationStats = Stats
+data PerOperationStats = PerOperationStats
   { count :: !Int
   , min_ns :: !Word64
   , max_ns :: !Word64
@@ -26,6 +27,9 @@ main = do
   case args of
     [path] -> do
       (opCounts:: H.CuckooHashTable T.Text PerOperationStats) <- H.new
+      max_threads <- newIORef 0
+      max_alloc <- newIORef 0
+      max_live <- newIORef 0
       let span_exporter = Exporter
             (\sps -> do
               forM_ sps $ \sp -> do
@@ -34,9 +38,9 @@ main = do
                   opCounts
                   (spanOperation sp)
                   (\m -> (Just $ maybe
-                                  (Stats 0 maxBound 0 0)
-                                  (\Stats {..} ->
-                                    Stats
+                                  (PerOperationStats 0 maxBound 0 0)
+                                  (\PerOperationStats {..} ->
+                                    PerOperationStats
                                     (count + 1)
                                     (min min_ns duration)
                                     (max max_ns duration)
@@ -44,13 +48,22 @@ main = do
                                   m, ()))
               pure ExportSuccess)
             (pure ())
-          metric_exporter = noopExporter
+          metric_exporter = Exporter
+              ( \metrics -> do
+                  forM_ metrics $ \(Gauge time label value) ->
+                    case T.unpack label of
+                      "threads" -> modifyIORef max_threads (max value)
+                      "heap_alloc_bytes" -> modifyIORef max_alloc (max value)
+                      "heap_live_bytes" -> modifyIORef max_live (max value)
+                  pure ExportSuccess
+              )
+              (pure ())
       exportEventlog span_exporter metric_exporter path
       leaderboard <- sortOn (total_ns . snd) <$> H.toList opCounts
       printf "Count\tTot ms\tMin ms\tMax ms\tOperation\n"
       printf "-----\t------\t------\t------\t---------\n"
       mapM_
-        (\(op, Stats {..}) ->
+        (\(op, PerOperationStats {..}) ->
           printf "%d\t%d\t%d\t%d\t%s\n"
             count
             (total_ns `div` 1000000)
@@ -58,6 +71,10 @@ main = do
             (max_ns `div` 1000000)
             (T.unpack op))
         leaderboard
+      putStrLn "---"
+      printf "Max threads: %v\n"  =<< readIORef max_threads
+      printf "Max allocated: %vMB\n" . (`div` 10^6) =<< readIORef max_alloc
+      printf "Max live: %vMB\n" . (`div` 10^6) =<< readIORef max_live
       putStrLn "It's fine"
     _ -> do
       putStrLn "Usage:"

--- a/opentelemetry-extra/src/OpenTelemetry/EventlogStreaming_Internal.hs
+++ b/opentelemetry-extra/src/OpenTelemetry/EventlogStreaming_Internal.hs
@@ -171,7 +171,7 @@ processEvent (Event ts ev m_cap) st@(S {..}) =
           (st {gcStartedAt = now}, [], [])
         (HeapLive {liveBytes}, _, _) -> (st, [], [Gauge now "heap_live_bytes" $ fromIntegral liveBytes])
         (HeapAllocated {allocBytes}, (Just cap), _) ->
-          (st, [], [Gauge now ("heap_alloc_bytes_" <> (T.pack $ show cap)) $ fromIntegral allocBytes])
+          (st, [], [Gauge now ("cap_" <> T.pack (show cap) <> "_heap_alloc_bytes") $ fromIntegral allocBytes])
         (EndGC, _, _) ->
           let (span_id, randomGen') = R.nextWord64 randomGen
               sp = Span

--- a/opentelemetry-extra/src/OpenTelemetry/EventlogStreaming_Internal.hs
+++ b/opentelemetry-extra/src/OpenTelemetry/EventlogStreaming_Internal.hs
@@ -170,7 +170,8 @@ processEvent (Event ts ev m_cap) st@(S {..}) =
         (StartGC, _, _) ->
           (st {gcStartedAt = now}, [], [])
         (HeapLive {liveBytes}, _, _) -> (st, [], [Gauge now "heap_live_bytes" $ fromIntegral liveBytes])
-        (HeapAllocated {allocBytes}, _, _) -> (st, [], [Gauge now "heap_alloc_bytes" $ fromIntegral allocBytes])
+        (HeapAllocated {allocBytes}, (Just cap), _) ->
+          (st, [], [Gauge now ("heap_alloc_bytes_" <> (T.pack $ show cap)) $ fromIntegral allocBytes])
         (EndGC, _, _) ->
           let (span_id, randomGen') = R.nextWord64 randomGen
               sp = Span


### PR DESCRIPTION
Show a rough summary (just maxima for now) of metric data in eventlog-summary.

Example:

```
...
Max threads: 395
Max allocated: 1814MB
Max live: 276MB
It's fine
```