### PR TITLE
Report total allocations per-capability in eventlog-summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,41 +65,42 @@ TODO: Document how to export trace data to Chrome or Tracy.
 This is the simplest kind of exporter that doesn't send the trace to any external application or service but prints some statistics about a given eventlog.
 
 ```
-> eventlog-summary stack.eventlog
-Count   Tot ms  Min ms  Max ms  Operation
------   ------  ------  ------  ---------
-1       0       0       0       Build.build_setLocalFiles
-1       0       0       0       Main.buildCmd_before_inner
-1       0       0       0       Build.Source.loadSourceMap
-1       0       0       0       Build.Execute.getSetupExe
-1       0       0       0       Build.Source.localDependencies
-1       0       0       0       Build.mkBaseConfigOpts
-1       0       0       0       Build.Installed.toInstallMap
-1       0       0       0       Lock.loadYamlThrow
-1       0       0       0       Build.build_checkComponentsBuildable
-1       0       0       0       Config.loadProjectConfig
-3       0       0       0       Config.loadConfigYaml
-1       0       0       0       Build.Execute.executePlan
-1       4       4       4       Build.Source.projectLocalPackages
-9       6       0       1       Storage.Project.loadConfigCache
-19      7       0       1       Build.Source.loadLocalPackage
-1       23      23      23      Build.ConstructPlan.constructPlan
-1       51      51      51      setupEnv
-1       126     126     126     Pantry.loadAndCompleteSnapshotRaw
-1       128     128     128     Lock.lockCacheWanted
-1131    212     0       8       gc
-1       246     246     246     Build.Installed.getInstalled
-1       275     275     275     Build.build
-1       328     328     328     Storage.Project.initProjectStorage
-5       387     45      109     sinkProcessStdout
-5       387     45      109     PackageDump.ghcPkgCmdArgs
-5       408     46      116     Build.Installed.loadDatabase
-1       456     456     456     Config.withBuildConfig
-1       463     463     463     Config.loadConfig
-1       463     463     463     Runners.withConfig
-1       463     463     463     Main.buildCmd_inner
-1       463     463     463     Main.buildCmd
-1       472     472     472     Main.main
+> eventlog-summary ghcide.eventlog
+Count	Tot ms	Min ms	Max ms	Operation
+-----	------	------	------	---------
+3       0       0        0      GetDependencies
+3       0       0        0      GhcSessionDeps
+3       0       0        0      PackageExports HscEnvEq 18
+8       0       0        0      GhcSessionIO
+8       0       0        0      GetFilesOfInterest
+5       1       0        0      Request:DocumentHighlight
+18      5       0        0      Request:Hover
+45      10      0        0      Request:Definition
+131     19      0        4      IsFileOfInterest
+275     35      0        7      GetModificationTime
+71      42      0        13     GetDependencyInformation
+152     45      0        10     GetFileContents
+3       123     0        83     GetHieFile
+152     144     0        73     GhcSession
+71      170     0        32     ReportImportCycles
+2       176     87       88     GetModuleGraph
+7       194     0        154    GetDocMap
+8       298     0        182    GetParsedModule
+8       486     0        229    TypeCheck
+8472    566     0        15     GetFileExists
+9       1395    43       367    gc
+149     3877    0        709    GetModSummary
+147     9496    0        739    GetLocatedImports
+122     18707   0        902    GetModIfaceFromDisk
+130     28106   0        6302   GetModIface
+---
+Max threads: 395
+Total allocations:
+  * Capability 0: 1316MB
+  * Capability 1: 1814MB
+  * Capability 2: 1153MB
+  * Capability 3: 1136MB
+Max live: 276MB
 It's fine
 ```
 

--- a/opentelemetry-extra/exe/eventlog-summary/Main.hs
+++ b/opentelemetry-extra/exe/eventlog-summary/Main.hs
@@ -96,7 +96,8 @@ main = do
       putStrLn ""
       putStrLn "  eventlog-summary <program.eventlog>"
 
--- | Parse
+-- | Parse capability number out of event/metric name. If it fails, returns
+-- (Nothing, the original string)
 splitCapability :: String -> (Maybe Int, String)
 splitCapability fullName@('c':'a':'p':'_':rest) =
   case span isDigit rest of

--- a/opentelemetry-extra/exe/eventlog-summary/Main.hs
+++ b/opentelemetry-extra/exe/eventlog-summary/Main.hs
@@ -39,9 +39,6 @@ main = do
     [path] -> do
       (opCounts:: H.CuckooHashTable T.Text PerOperationStats) <- H.new
       metricStats <- newIORef (MetricStats 0 IntMap.empty 0)
-      -- max_threads <- newIORef 0
-      -- max_alloc <- newIORef 0
-      -- max_live <- newIORef 0
       let span_exporter = Exporter
             (\sps -> do
               forM_ sps $ \sp -> do

--- a/opentelemetry-extra/exe/eventlog-summary/Main.hs
+++ b/opentelemetry-extra/exe/eventlog-summary/Main.hs
@@ -14,7 +14,6 @@ import Data.List (sortOn)
 import Data.Word
 import Data.IORef
 import Data.Char (isDigit)
-import Debug.Trace
 
 type HashTable k v = H.BasicHashTable k v
 
@@ -64,7 +63,7 @@ main = do
                       (_, "threads") -> s { max_threads = max value (max_threads s) }
                       (Just cap, "heap_alloc_bytes") -> s { total_alloc_bytes = IntMap.insert cap value (total_alloc_bytes s) }
                       (_, "heap_live_bytes") -> s { max_live_bytes = max value (max_live_bytes s) }
-                      _ -> traceShow label s
+                      _ -> s
                   pure ExportSuccess
               )
               (pure ())

--- a/opentelemetry-extra/opentelemetry-extra.cabal
+++ b/opentelemetry-extra/opentelemetry-extra.cabal
@@ -170,6 +170,7 @@ executable eventlog-summary
   build-depends:
     base,
     hashtables,
+    containers,
     opentelemetry >= 0.4.0,
     opentelemetry-extra,
     text


### PR DESCRIPTION
Example output:
```
...
---
Max threads: 395
Total allocations:
  * Capability 0: 1316MB
  * Capability 1: 1814MB
  * Capability 2: 1153MB
  * Capability 3: 1136MB
Max live: 276MB
It's fine
```
I wanted to add example output to the README but I'm not sure how to get an eventlog out of stack (since the example there currently is from stack). Marked as draft because of this. I could replace the example there with one from `ghcide` since that would be a bit easier for me to get.
