### PR TITLE
Add info about eventlog-summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,12 @@ TODO: Document how to export trace data to Chrome or Tracy.
 
 ### Eventlog summary
 
-This is the simplest kind of exporter that doesn't send the trace to any external application or service but prints some statistics about a given eventlog.
+This is the simplest kind of exporter that doesn't send the trace to
+any external application or service but prints some statistics about a
+given eventlog. This is one of the executables bundled as part of
+[opentelemetry-extra](https://hackage.haskell.org/package/opentelemetry-extra
+"opentelemetry-extra") package which is developed as part of this
+repository.
 
 ```
 > eventlog-summary ghcide.eventlog


### PR DESCRIPTION
The motivation of the PR is to add some details about the
eventlog-summary program so that users can know from where to get
it (I was confused as I'm new to the ecosystem.)